### PR TITLE
#54 Fix velero deployment restore disruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#54] Restore of the velero deployment disrupted the restore
+  - Previously, the Velero deployment would get restored as well,
+    which caused disruptions of the restore if the deployment is different
+    from the one in the backup.
+### Changed
+- [#54] Exclude all resources with label `k8s.cloudogu.com/part-of: backup` from restores.
 
 ## [v1.4.0] - 2025-05-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Previously, the Velero deployment would get restored as well,
     which caused disruptions of the restore if the deployment is different
     from the one in the backup.
+- [#56] Cleanup of backup components lead to errors after restore
+  - This is because the component operator would detect a downgrade, which is not allowed.
+    Or worse, an upgrade during the restore operation would cause it to fail.
 ### Changed
 - [#54] Exclude all resources with label `k8s.cloudogu.com/part-of: backup` from restores.
+- [#56] Exclude all backup-related components from cleanup when restoring.
 
 ## [v1.4.0] - 2025-05-07
 ### Added

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -10,7 +10,27 @@ cleanup:
   exclude: # group, version, kind, name
     - name: "ces-loadbalancer"
       kind: "Service"
-      version: "v1"
+      version: "*"
+    - name: "k8s-backup-operator"
+      kind: "Component"
+      version: "*"
+      group: "k8s.cloudogu.com"
+    - name: "k8s-backup-operator-crd"
+      kind: "Component"
+      version: "*"
+      group: "k8s.cloudogu.com"
+    - name: "k8s-snapshot-controller"
+      kind: "Component"
+      version: "*"
+      group: "k8s.cloudogu.com"
+    - name: "k8s-snapshot-controller-crd"
+      kind: "Component"
+      version: "*"
+      group: "k8s.cloudogu.com"
+    - name: "k8s-velero"
+      kind: "Component"
+      version: "*"
+      group: "k8s.cloudogu.com"
 manager:
   env:
     stage: production

--- a/pkg/velero/restoreManager.go
+++ b/pkg/velero/restoreManager.go
@@ -38,15 +38,11 @@ func (rm *defaultRestoreManager) CreateRestore(ctx context.Context, restore *v1.
 				// Filter backup-operator from restore.
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{
-						Key:      "app.kubernetes.io/name",
+						Key:      "k8s.cloudogu.com/part-of",
 						Operator: metav1.LabelSelectorOpNotIn,
-						Values:   []string{"k8s-backup-operator"},
+						Values:   []string{"backup"},
 					},
-					{
-						Key:      "app.kubernetes.io/part-of",
-						Operator: metav1.LabelSelectorOpNotIn,
-						Values:   []string{"k8s-backup-operator"},
-					}},
+				},
 			},
 		},
 	}
@@ -103,6 +99,8 @@ func waitForRestoreCompletionOrFailure(ctx context.Context, veleroRestoreChan <-
 			case velerov1.RestorePhaseCompleted:
 				return nil
 			}
+		case watch.Error:
+			return fmt.Errorf("")
 		}
 	}
 

--- a/pkg/velero/restoreManager.go
+++ b/pkg/velero/restoreManager.go
@@ -99,8 +99,6 @@ func waitForRestoreCompletionOrFailure(ctx context.Context, veleroRestoreChan <-
 			case velerov1.RestorePhaseCompleted:
 				return nil
 			}
-		case watch.Error:
-			return fmt.Errorf("")
 		}
 	}
 

--- a/pkg/velero/restoreManager_test.go
+++ b/pkg/velero/restoreManager_test.go
@@ -188,10 +188,11 @@ func getExpectedVeleroRestore(restore *v1.Restore) *velerov1.Restore {
 			BackupName:             restore.Spec.BackupName,
 			ExistingResourcePolicy: velerov1.PolicyTypeUpdate,
 			RestoreStatus:          &velerov1.RestoreStatusSpec{IncludedResources: []string{"*"}},
-			LabelSelector: &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{Key: "app.kubernetes.io/name", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"k8s-backup-operator"}},
-					{Key: "app.kubernetes.io/part-of", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"k8s-backup-operator"}}}}}}
+			LabelSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "k8s.cloudogu.com/part-of", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"backup"}},
+			}},
+		},
+	}
 }
 
 func runVeleroStatusPhaseFailureTest(t *testing.T, phase velerov1.RestorePhase) {


### PR DESCRIPTION
Previously, the Velero deployment would get restored as well,
 which caused disruptions of the restore if the deployment is different
 from the one in the backup.

Resolves #54 
Resolves #56 